### PR TITLE
changed format

### DIFF
--- a/wdh_server/templates/article.html
+++ b/wdh_server/templates/article.html
@@ -21,21 +21,7 @@
 		</dd>
 		{% endif %}
 
-		<dt>authors</dt>
-		<dd>
-			<ul>
-				{% for handle in article.authors %}
-				<li>
-					<a href="{{ url_for("author", handle=handle) }}"
-							rel="http://rels.example.org/author">
-						{{ handle }}
-					</a>
-				</li>
-				{% endfor %}
-			</ul>
-		</dd>
-
-		<dt>tags</dt>
+        <dt>tags</dt>
 		<dd>
 			<ul>
 				{% for tag in article.tags %}
@@ -50,5 +36,17 @@
 		<dt>content</dt>
 		<dd data-type="text/html">{{ article.content }}</dd>
 	</dl>
+
+    <p>authors</p>
+    <ul>
+        {% for handle in article.authors %}
+        <li>
+            <a href="{{ url_for("author", handle=handle) }}"
+                    rel="http://rels.example.org/author">
+                {{ handle }}
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
 </article>
 {% endblock %}

--- a/wdh_server/templates/articles.html
+++ b/wdh_server/templates/articles.html
@@ -5,27 +5,30 @@
 <ul>
 	{% for article in articles %}
 	<li>
-		<a href="#article{{ article.id }}" rel="http://rels.example.org/article"></a>
-		<article id="article{{ article.id }}">
-			<h1>
-				<a href="{{ url_for("article", article_id=article.id) }}" rel="self">
-					{{ article.title }}
-				</a>
-			</h1>
-			<dl>
-				<dt>title</dt>
-				<dd>{{ article.title }}</dd>
+        <details>
+            <summary>
+                <h1>
+		            <a href="{{ url_for("article", article_id=article.id) }}" rel="http://rels.example.org/article">
+                        {{ article.title }}
+                    </a>
+                </h1>
+            </summary>
+            <article id="article{{ article.id }}">
+                <dl>
+                    <dt>title</dt>
+                    <dd>{{ article.title }}</dd>
 
-				{% if article.pubdate %}
-				<dt>pubdate</dt>
-				<dd>
-					<time datetime="{{ article.pubdate }}">
-						{{ article.pubdate }}
-					</time>
-				</dd>
-				{% endif %}
-			</dl>
-		</article>
+                    {% if article.pubdate %}
+                    <dt>pubdate</dt>
+                    <dd>
+                        <time datetime="{{ article.pubdate }}">
+                            {{ article.pubdate }}
+                        </time>
+                    </dd>
+                    {% endif %}
+                </dl>
+            </article>
+        </details>
 	</li>
 	{% endfor %}
 </ul>


### PR DESCRIPTION
- no rel="self" in embeds, instead
- embeds are like the following:

```
    <details>
        <summary>
            <a rel="rels.example.com/example" href="examples/example">Example</a>
        </summary>
        <article>...</article>
    </details>
```
- properties which point to resources aren't allowed in `<dd>` tags.
  They have to be recognized by their rel attribute
